### PR TITLE
Removed html package as dependency

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -12,8 +12,7 @@
     "dependencies": {
         "billstclair/elm-bitwise-infix": "1.0.2 <= v < 2.0.0",
         "elm-community/list-extra": "4.0.0 <= v < 5.0.0",
-        "elm-lang/core": "5.0.0 <= v < 6.0.0",
-        "elm-lang/html": "2.0.0 <= v < 3.0.0"
+        "elm-lang/core": "5.0.0 <= v < 6.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -10,7 +10,6 @@
     "exposed-modules": [],
     "dependencies": {
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
-        "elm-lang/html": "2.0.0 <= v < 3.0.0",
         "elm-community/list-extra": "4.0.0 <= v < 5.0.0",
         "elm-community/elm-test": "3.0.0 <= v < 4.0.0",
         "rtfeldman/node-test-runner": "3.0.0 <= v < 4.0.0",


### PR DESCRIPTION
I'd like to use this package in non-browser contexts. Since the html package is not actually used, can we remove it?